### PR TITLE
Download into the correct directory when using wget to download a theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the previews for each theme in the [section](#previews) below or in this other
    - or download just one theme:
       ```bash
       THEME=https://raw.githubusercontent.com/dexpota/kitty-themes/master/themes/3024_Day.conf
-      wget "$THEME" -P ~/.config/kitty/kitty-themes
+      wget "$THEME" -P ~/.config/kitty/kitty-themes/themes
       ```
 
 2. Choose a theme and create a symlink:


### PR DESCRIPTION
Fixes https://github.com/dexpota/kitty-themes/issues/14.
Step 2 in the documentation recommends to create a symlink which relies on the theme being in the `themes` directory.

I think that adding the `themes` directory is less confusing than showing an alternative symlink command in step 2.