### PR TITLE
fixing shadow color  for auto suggestion zsh plugin

### DIFF
--- a/themes/gruvbox_dark.conf
+++ b/themes/gruvbox_dark.conf
@@ -11,7 +11,7 @@ selection_foreground  #928374
 selection_background  #3c3836
 
 color0  #282828
-color8  #fbf1c7
+color8  #928374
 
 # red
 color1                #cc241d


### PR DESCRIPTION
---
name: fix gruvbox_dark
assignees: dexpota

---
Please, include **theme** in the collection.
