### PR TITLE
Fix Solarized Dark background colors

### DIFF
--- a/themes/Solarized_Dark.conf
+++ b/themes/Solarized_Dark.conf
@@ -1,7 +1,7 @@
-background #001e26
-foreground #708183
+background #002b36
+foreground #839496
 cursor #708183
-selection_background #002731
+selection_background #073642
 color0 #002731
 color8 #001e26
 color1 #d01b24
@@ -18,4 +18,4 @@ color6 #259185
 color14 #81908f
 color7 #e9e2cb
 color15 #fcf4dc
-selection_foreground #001e26
+selection_foreground #93a1a1


### PR DESCRIPTION
Solarized [explicitly defines][1] background and foreground colors:
* `#002b36` (`base03`) for background
* `#839496` (`base0`) for primary content (foreground)
* `#073642` (`base02`) for highlights
* `#93a1a1` (`base1`) for highlighted content

[1]: https://ethanschoonover.com/solarized/#usage-development