### PR TITLE
Add 1984/1984-light/1984-orwellian themes

### DIFF
--- a/themes/1984-light.conf
+++ b/themes/1984-light.conf
@@ -1,0 +1,29 @@
+# 1984 light theme by Bertie Blackman, https://github.com/covertbert/iterm2-1984/
+
+foreground #19152c
+background #e4e5f5
+selection_foreground #19152c
+selection_background #ff16b0
+color0 #000000
+color1 #ff16b0
+color2 #00af4f
+color3 #ff8d01
+color4 #0098fd
+color5 #f806fa
+color6 #00b2be
+color7 #feffff
+color8 #000000
+color9 #ff16b0
+color10 #00af4f
+color11 #ff8d01
+color12 #0098fd
+color13 #f806fa
+color14 #00b2be
+color15 #feffff
+
+# URL styles
+url_color #ff16b0
+url_style single
+
+# Cursor styles
+cursor #00b2be

--- a/themes/1984-orwellian.conf
+++ b/themes/1984-orwellian.conf
@@ -1,0 +1,29 @@
+# 1984 orwellian theme by Bertie Blackman, https://github.com/covertbert/iterm2-1984/
+
+foreground #f1f1f1
+background #2e2923
+selection_foreground #000000
+selection_background #3fc4ce
+color0 #000000
+color1 #e74946
+color2 #4cb605
+color3 #fcd395
+color4 #356fe4
+color5 #fcbe95
+color6 #3fc4ce
+color7 #f1f1f1
+color8 #000000
+color9 #e74946
+color10 #4cb605
+color11 #fcd395
+color12 #356fe4
+color13 #fcbe95
+color14 #3fc4ce
+color15 #f1f1f1
+
+# URL styles
+url_color #e74946
+url_style single
+
+# Cursor styles
+cursor #3fc4ce

--- a/themes/1984.conf
+++ b/themes/1984.conf
@@ -1,0 +1,29 @@
+# 1984 theme by Bertie Blackman, https://github.com/covertbert/iterm2-1984/
+
+foreground #ffffff
+background #0d0f31
+selection_foreground #000000
+selection_background #00d5eb
+color0 #000000
+color1 #ff16b0
+color2 #b3f361
+color3 #ffea16
+color4 #46bdff
+color5 #f806fa
+color6 #59e1e3
+color7 #feffff
+color8 #000000
+color9 #ff16b0
+color10 #b3f361
+color11 #ffea16
+color12 #46bdff
+color13 #f806fa
+color14 #6be4e6
+color15 #feffff
+
+# URL styles
+url_color #f806fa
+url_style single
+
+# Cursor styles
+cursor #59e1e3


### PR DESCRIPTION
Converted from iterm2 themes - https://github.com/covertbert/iterm2-1984

---
name: theme-request
about: Use the following template if you want a new theme to be included in the collection.
title: Add 1984/1984-light/1984-orwellian themes to the collection.
labels: theme request
assignees: dexpota

---
Please, include **1984 / 1984-light / 1984-orwellian** themes in the collection.
