### PR TITLE
Update Solarized_Dark.conf

### DIFF
--- a/themes/Solarized_Dark.conf
+++ b/themes/Solarized_Dark.conf
@@ -1,7 +1,7 @@
 background #001e26
 foreground #708183
 cursor #708183
-selection_background #002731
+selection_background #93a1a1
 color0 #002731
 color8 #001e26
 color1 #d01b24
@@ -18,4 +18,4 @@ color6 #259185
 color14 #81908f
 color7 #e9e2cb
 color15 #fcf4dc
-selection_foreground #001e26
+selection_foreground #002b36


### PR DESCRIPTION
'Selection' is almost invisible - too little contrast. So I've substituted the values from the emacs solarised-dark theme.

---
name: theme-request
about: Use the following template if you want a new theme to be included in the collection.
title: Add <theme> to the collection.
labels: theme request
assignees: dexpota

---
Please, include **theme** in the collection.
