### PR TITLE
Update gruvbox_dark.conf from upstream

### DIFF
--- a/themes/gruvbox_dark.conf
+++ b/themes/gruvbox_dark.conf
@@ -26,7 +26,7 @@ color10               #b8bb26
 # yellow
 color3                #d79921
 # light yellow
-color11               #fabd2d
+color11               #fabd2f
 
 # blue
 color4                #458588


### PR DESCRIPTION
---
name: theme-request
about: Use the following template if you want a new theme to be included in the collection.
title: Add gruvbox dark to the collection.
labels: theme request
assignees: dexpota

---
Please, include **gruvbox dark** in the collection.
Source: https://github.com/morhetz/gruvbox