### PR TITLE
Document how to preview a theme via the kitty shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,21 @@ you find your theme inside this repository and you want a proper citation.
 ## Previews
 
 If you have followed the [installation](#installation) instructions and cloned
-the entire repo, you have two options to try a theme:
+the entire repo, you have three options to try a theme:
 
-1. If you have enabled remote control in *kitty* you can run this command:
+1. You can open the kitty shell (`ctrl+shift+escape`) and run this command:
+
+    ```bash
+    set-colors -a "~/.config/kitty/kitty-themes/themes/AdventureTime.conf"
+    ```
+
+2. If you have enabled remote control in *kitty* you can run this command:
 
     ```bash
     kitty @ set-colors -a "~/.config/kitty/kitty-themes/themes/AdventureTime.conf"
     ```
 
-2. Otherwise you can start another instance of kitty and specify another config
+3. Otherwise you can start another instance of kitty and specify another config
   file to read from, this will cause *kitty* to read both its normal config
   file and the specified one:
 


### PR DESCRIPTION
Hi, thanks for this project, it's fantastic! :100: 

As I was previewing themes, I noticed that there is another way to preview themes that I found easier: you can open the Kitty shell (`ctrl+shift+escape`) and run `set-colors` there directly.

I thought other folks might find this information useful, so here is a PR adding it to the README. Feedback welcome!